### PR TITLE
Fix finding the latest version tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test: ${generated_files} #> Run the test suite
 
 release: all #! Place artifacts on GitHub
 	# find the most recent version tag
-	tag=$$(git tag --list 'v*' | head -1); \
+	tag=$$(git tag --list 'v*' | tail -1); \
 	echo "Creating a release for version $${tag}"; \
 	gh release create $${tag} ${release_artifacts}
 


### PR DESCRIPTION
Using tail, not head, to grab the latest version tag.
